### PR TITLE
Add returned peer fields last_handshake_time, rx_bytes and tx_bytes

### DIFF
--- a/wireguard_py/wgpy.py
+++ b/wireguard_py/wgpy.py
@@ -159,6 +159,12 @@ def list_peers(device_name) -> None:
             print(f"  allowed ips: {', '.join(str(ip) for ip in peer.allowed_ips)}")
         else:
             print("  allowed ips: (none)")
+        if peer.last_handshake_time is not None:
+            print(f"  last handshake time: {peer.last_handshake}")
+        if peer.rx_bytes is not None:
+            print(f"  rx bytes: {peer.rx_bytes}")
+        if peer.tx_bytes is not None:
+            print(f"  tx bytes: {peer.tx_bytes}")
         print("")
 
 

--- a/wireguard_py/wgpy.py
+++ b/wireguard_py/wgpy.py
@@ -160,7 +160,7 @@ def list_peers(device_name) -> None:
         else:
             print("  allowed ips: (none)")
         if peer.last_handshake_time is not None:
-            print(f"  last handshake time: {peer.last_handshake}")
+            print(f"  last handshake time: {peer.last_handshake_time}")
         if peer.rx_bytes is not None:
             print(f"  rx bytes: {peer.rx_bytes}")
         if peer.tx_bytes is not None:

--- a/wireguard_py/wireguard_common.py
+++ b/wireguard_py/wireguard_common.py
@@ -27,6 +27,9 @@ class Peer:
     pubkey: str
     endpoint: Optional[Endpoint] = None
     allowed_ips: List[IPNetwork] = field(default_factory=list)
+    last_handshake_time: Optional[int] = None
+    rx_bytes: Optional[int] = None
+    tx_bytes: Optional[int] = None
 
     def __str__(self) -> str:
         return self.pubkey

--- a/wireguard_py/wireguard_py.pxd
+++ b/wireguard_py/wireguard_py.pxd
@@ -7,6 +7,9 @@ This software may be used and distributed according to the terms of the
 MIT License.
 """
 
+cdef extern from "stdint.h":
+    ctypedef unsigned long long uint64_t
+
 cdef extern from "net/if.h":
     cdef const int IFNAMSIZ
 
@@ -80,7 +83,7 @@ cdef extern from "wireguard_py/wireguard_tools/wireguard.h":
         int flags
         wg_key public_key
         wg_endpoint endpoint
-        struct timespec64 last_handshake_time
+        timespec64 last_handshake_time
         uint64_t rx_bytes
         uint64_t tx_bytes
         wg_allowedip *first_allowedip

--- a/wireguard_py/wireguard_py.pxd
+++ b/wireguard_py/wireguard_py.pxd
@@ -80,6 +80,9 @@ cdef extern from "wireguard_py/wireguard_tools/wireguard.h":
         int flags
         wg_key public_key
         wg_endpoint endpoint
+        struct timespec64 last_handshake_time
+        uint64_t rx_bytes
+        uint64_t tx_bytes
         wg_allowedip *first_allowedip
         wg_allowedip *last_allowedip
         wg_peer *next_peer

--- a/wireguard_py/wireguard_py.pyx
+++ b/wireguard_py/wireguard_py.pyx
@@ -312,6 +312,11 @@ def list_peers(device_name: bytes) -> List[Peer]:
                         break
 
                     allowedip = allowedip.next_allowedip
+            
+            # Add last_handshake_time, rx_bytes, and tx_bytes
+            peer_py.last_handshake_time = peer.last_handshake_time
+            peer_py.rx_bytes = peer.rx_bytes
+            peer_py.tx_bytes = peer.tx_bytes
 
             peers.append(peer_py)
 

--- a/wireguard_py/wireguard_py.pyx
+++ b/wireguard_py/wireguard_py.pyx
@@ -314,7 +314,7 @@ def list_peers(device_name: bytes) -> List[Peer]:
                     allowedip = allowedip.next_allowedip
             
             # Add last_handshake_time, rx_bytes, and tx_bytes
-            peer_py.last_handshake_time = peer.last_handshake_time
+            peer_py.last_handshake_time = peer.last_handshake_time.tv_sec
             peer_py.rx_bytes = peer.rx_bytes
             peer_py.tx_bytes = peer.tx_bytes
 


### PR DESCRIPTION

## Description
This pull request enhances the `wireguard_py` library by adding additional peer statistics and making necessary adjustments to support these new attributes. The most important changes include updating the `Peer` class to include new fields, modifying the `list_peers` function to display these new statistics, and adjusting the Cython interface to handle the new data.

Enhancements to peer statistics:

* [`wireguard_py/wireguard_common.py`](diffhunk://#diff-0077496157ef4c906a17731eedf5096f8840d2cd5c7272fb0aa643a50bf38a5fR30-R32): Added `last_handshake_time`, `rx_bytes`, and `tx_bytes` as optional fields to the `Peer` class.
* [`wireguard_py/wgpy.py`](diffhunk://#diff-f0e391a707d5f01454fc50fbd14281339b343c7bdd05b2100834aebb1ed82ab1R162-R167): Updated the `list_peers` function to print the new fields `last_handshake_time`, `rx_bytes`, and `tx_bytes` if they are not `None`.

Adjustments to Cython interface:

* [`wireguard_py/wireguard_py.pxd`](diffhunk://#diff-234a176f300f3e6037939ff0b5b2fa2d50d4e186c4b47fa4567166a3be432b98R10-R12): Introduced `uint64_t` from `stdint.h` and added `timespec64`, `rx_bytes`, and `tx_bytes` to the `wg_peer` structure. [[1]](diffhunk://#diff-234a176f300f3e6037939ff0b5b2fa2d50d4e186c4b47fa4567166a3be432b98R10-R12) [[2]](diffhunk://#diff-234a176f300f3e6037939ff0b5b2fa2d50d4e186c4b47fa4567166a3be432b98R86-R88)
* [`wireguard_py/wireguard_py.pyx`](diffhunk://#diff-13b02d2b616cbbe8a53e361273a34f9b131b1ea17c623a0db91a0ac992f89a4dR316-R320): Modified the `list_peers` function to assign `last_handshake_time`, `rx_bytes`, and `tx_bytes` from the C structure to the Python `Peer` object.

## Motivation and Context
The list_peers method was not returning the last_hanshake_time  rx_bytes and tx_bytes returned by the kernel call making it impossible to use it to monitor peer status and statistics: Resolves #3 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `wgpy.py` script from the module -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
Tests have been realised on an Ubuntu server with active peers on an existing interface with the modified wgpy.py to ensure that peers that have never connected and peers that has already connected have returned either values of 0 when never connected or valid values when already connected when the wgpy.py list-peers <interface> was called.
I have also tested with a loop creating up to 40 peers to make sure that the list-peers returns all the created peers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation.
